### PR TITLE
updating jq search url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,16 @@
 module github.com/hashicorp/gh-action-jira-search
 
-go 1.14
+go 1.25.0
 
 require (
 	github.com/hashicorp/gh-action-jira v0.3.0
 	github.com/stretchr/testify v1.6.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,5 +13,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func findIssueKeys(config config.JiraConfig, jql string) ([]string, error) {
 		"jql":    {jql},
 		"fields": {"summary"}, // Specify fields summary purely to minimise the size of all the unused fields in the response.
 	}
-	respBody, err := jira.DoRequest(config, "GET", "/rest/api/3/search", query, nil)
+	respBody, err := jira.DoRequest(config, "GET", "/rest/api/3/search/jql", query, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Our jira search step started failing in CI because the search API changed: https://developer.atlassian.com/changelog/#CHANGE-2046

Example: https://github.com/hashicorp/vault-csi-provider/actions/runs/17471972869/job/49622365438#step:4:21

With this patch:

```console
❯ GITHUB_OUTPUT=/tmp/hello.github JIRA_BASE_URL=${JIRA_SYNC_BASE_URL?} \
  JIRA_USER_EMAIL=${JIRA_SYNC_USER_EMAIL?} JIRA_API_TOKEN=${JIRA_SYNC_API_TOKEN?} \
  INPUT_JQL='project = "VAULT" and cf[10089]="https://github.com/hashicorp/vault-helm/pull/1131"' \
  go run main.go
Found issue VAULT-39201

❯ cat /tmp/hello.github 
key=VAULT-39201
```